### PR TITLE
fix(#22): Reduce redundant memory consumption by using cacheTask + cursor for loading embeddings

### DIFF
--- a/Sharkfin/Search/SearchService.swift
+++ b/Sharkfin/Search/SearchService.swift
@@ -24,7 +24,8 @@ final class SearchService: @unchecked Sendable {
   
   // MARK: - Embedding cache
   
-  private let cache = OSAllocatedUnfairLock<EmbeddingCache?>(initialState: nil)
+  private let cacheTask = OSAllocatedUnfairLock<Task<EmbeddingCache, any Error>?>(initialState: nil)
+  private let debounceTask = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
   private var notificationObserver: (any NSObjectProtocol)?
   
   init(database: AppDatabase, textEncoder: any TextEncoding) {
@@ -36,7 +37,7 @@ final class SearchService: @unchecked Sendable {
       object: nil,
       queue: nil
     ) { [weak self] _ in
-      self?.invalidateCache()
+      self?.scheduleInvalidation()
     }
   }
   
@@ -47,8 +48,21 @@ final class SearchService: @unchecked Sendable {
   }
   
   nonisolated func invalidateCache() {
-    cache.withLock { $0 = nil }
+    cacheTask.withLock { $0 = nil }
     LoggingService.shared.info("Cache invalidated", category: "Search")
+  }
+  
+  /// Debounce invalidation so rapid-fire notifications (e.g. multiple directories
+  /// finishing indexing) coalesce into a single cache reload.
+  private nonisolated func scheduleInvalidation() {
+    debounceTask.withLock { existing in
+      existing?.cancel()
+      existing = Task { [weak self] in
+        try? await Task.sleep(for: .milliseconds(500))
+        guard !Task.isCancelled else { return }
+        self?.invalidateCache()
+      }
+    }
   }
   
   nonisolated func search(
@@ -210,84 +224,105 @@ final class SearchService: @unchecked Sendable {
   // MARK: - Cache management
   
   private nonisolated func getCache() async throws -> EmbeddingCache {
-    if let existing = cache.withLock({ $0 }) {
-      return existing
+    let task = cacheTask.withLock { (task: inout Task<EmbeddingCache, any Error>?) -> Task<EmbeddingCache, any Error> in
+      if let task { return task }
+      let newTask = Task { try await loadCache() }
+      task = newTask
+      return newTask
     }
-    
-    let loaded = try await loadCache()
-    cache.withLock { $0 = loaded }
-    return loaded
+    return try await task.value
   }
   
   private nonisolated func loadCache() async throws -> EmbeddingCache {
-    let rows: [EmbeddingRow] = try await database.dbQueue.read { db in
-      try EmbeddingRow.fetchAll(
+    let sql = """
+      SELECT e.fileId, e.embedding, f.filename, f.path, f.thumbnailPath,
+             LOWER(f.fileExtension) AS fileExtension
+      FROM fileEmbeddings e
+      JOIN files f ON f.id = e.fileId
+      JOIN directories d ON d.id = f.directoryId
+      WHERE d.enabled = 1
+      """
+    
+    return try await database.dbQueue.read { db in
+      let count = try Int.fetchOne(
         db,
         sql: """
-          SELECT e.fileId, e.embedding, f.filename, f.path, f.thumbnailPath,
-                 LOWER(f.fileExtension) AS fileExtension
+          SELECT COUNT(*)
           FROM fileEmbeddings e
           JOIN files f ON f.id = e.fileId
           JOIN directories d ON d.id = f.directoryId
           WHERE d.enabled = 1
           """
-      )
-    }
-    
-    guard let firstRow = rows.first else {
-      return EmbeddingCache(
-        embeddings: [],
-        fileIds: [],
-        filenames: [],
-        paths: [],
-        thumbnailPaths: [],
-        fileExtensions: [],
-        count: 0,
-        dims: 0
-      )
-    }
-    
-    let dims = firstRow.embedding.count / MemoryLayout<Float>.size
-    var embeddings = [Float]()
-    embeddings.reserveCapacity(rows.count * dims)
-    var fileIds = [Int64]()
-    fileIds.reserveCapacity(rows.count)
-    var filenames = [String]()
-    filenames.reserveCapacity(rows.count)
-    var paths = [String]()
-    paths.reserveCapacity(rows.count)
-    var thumbnailPaths = [String?]()
-    thumbnailPaths.reserveCapacity(rows.count)
-    var fileExtensions = [String]()
-    fileExtensions.reserveCapacity(rows.count)
-    
-    for row in rows {
-      let floats: [Float] = row.embedding.withUnsafeBytes { buffer in
-        Array(buffer.bindMemory(to: Float.self))
+      ) ?? 0
+      
+      let cursor = try EmbeddingRow.fetchCursor(db, sql: sql)
+      
+      guard let firstRow = try cursor.next() else {
+        return EmbeddingCache(
+          embeddings: [],
+          fileIds: [],
+          filenames: [],
+          paths: [],
+          thumbnailPaths: [],
+          fileExtensions: [],
+          count: 0,
+          dims: 0
+        )
       }
-      guard floats.count == dims else { continue }
-      embeddings.append(contentsOf: floats)
-      fileIds.append(row.fileId)
-      filenames.append(row.filename)
-      paths.append(row.path)
-      thumbnailPaths.append(row.thumbnailPath)
-      fileExtensions.append(row.fileExtension ?? "")
+      
+      let dims = firstRow.embedding.count / MemoryLayout<Float>.size
+      var embeddings = [Float]()
+      embeddings.reserveCapacity(count * dims)
+      var fileIds = [Int64]()
+      fileIds.reserveCapacity(count)
+      var filenames = [String]()
+      filenames.reserveCapacity(count)
+      var paths = [String]()
+      paths.reserveCapacity(count)
+      var thumbnailPaths = [String?]()
+      thumbnailPaths.reserveCapacity(count)
+      var fileExtensions = [String]()
+      fileExtensions.reserveCapacity(count)
+      
+      // Process first row
+      firstRow.embedding.withUnsafeBytes { buffer in
+        embeddings.append(contentsOf: buffer.bindMemory(to: Float.self))
+      }
+      fileIds.append(firstRow.fileId)
+      filenames.append(firstRow.filename)
+      paths.append(firstRow.path)
+      thumbnailPaths.append(firstRow.thumbnailPath)
+      fileExtensions.append(firstRow.fileExtension ?? "")
+      
+      // Process remaining rows via cursor — only one row's Data is alive at a time
+      while let row = try cursor.next() {
+        let rowDims = row.embedding.count / MemoryLayout<Float>.size
+        guard rowDims == dims else { continue }
+        row.embedding.withUnsafeBytes { buffer in
+          embeddings.append(contentsOf: buffer.bindMemory(to: Float.self))
+        }
+        fileIds.append(row.fileId)
+        filenames.append(row.filename)
+        paths.append(row.path)
+        thumbnailPaths.append(row.thumbnailPath)
+        fileExtensions.append(row.fileExtension ?? "")
+      }
+      
+      LoggingService.shared.info(
+        "Cached \(fileIds.count) embeddings (\(dims) dims, \(embeddings.count * MemoryLayout<Float>.size / 1024)KB)",
+        category: "Search"
+      )
+      return EmbeddingCache(
+        embeddings: embeddings,
+        fileIds: fileIds,
+        filenames: filenames,
+        paths: paths,
+        thumbnailPaths: thumbnailPaths,
+        fileExtensions: fileExtensions,
+        count: fileIds.count,
+        dims: dims
+      )
     }
-    
-    LoggingService.shared.info(
-      "Cached \(fileIds.count) embeddings (\(dims) dims, \(embeddings.count * MemoryLayout<Float>.size / 1024)KB)",
-      category: "Search"
-    )
-    return EmbeddingCache(
-      embeddings: embeddings,
-      fileIds: fileIds,
-      filenames: filenames,
-      paths: paths,
-      thumbnailPaths: thumbnailPaths,
-      fileExtensions: fileExtensions,
-      count: fileIds.count,
-      dims: dims
-    )
   }
 }
 

--- a/Sharkfin/Search/SearchService.swift
+++ b/Sharkfin/Search/SearchService.swift
@@ -24,8 +24,7 @@ final class SearchService: @unchecked Sendable {
   
   // MARK: - Embedding cache
   
-  private let cacheTask = OSAllocatedUnfairLock<Task<EmbeddingCache, any Error>?>(initialState: nil)
-  private let debounceTask = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+  private let cacheState = OSAllocatedUnfairLock(initialState: CacheSlot())
   private var notificationObserver: (any NSObjectProtocol)?
   
   init(database: AppDatabase, textEncoder: any TextEncoding) {
@@ -37,7 +36,7 @@ final class SearchService: @unchecked Sendable {
       object: nil,
       queue: nil
     ) { [weak self] _ in
-      self?.scheduleInvalidation()
+      self?.invalidateCache()
     }
   }
   
@@ -48,21 +47,10 @@ final class SearchService: @unchecked Sendable {
   }
   
   nonisolated func invalidateCache() {
-    cacheTask.withLock { $0 = nil }
-    LoggingService.shared.info("Cache invalidated", category: "Search")
-  }
-  
-  /// Debounce invalidation so rapid-fire notifications (e.g. multiple directories
-  /// finishing indexing) coalesce into a single cache reload.
-  private nonisolated func scheduleInvalidation() {
-    debounceTask.withLock { existing in
-      existing?.cancel()
-      existing = Task { [weak self] in
-        try? await Task.sleep(for: .milliseconds(500))
-        guard !Task.isCancelled else { return }
-        self?.invalidateCache()
-      }
+    cacheState.withLock { state in
+      state.stale = true
     }
+    LoggingService.shared.info("Cache invalidated", category: "Search")
   }
   
   nonisolated func search(
@@ -224,13 +212,30 @@ final class SearchService: @unchecked Sendable {
   // MARK: - Cache management
   
   private nonisolated func getCache() async throws -> EmbeddingCache {
-    let task = cacheTask.withLock { (task: inout Task<EmbeddingCache, any Error>?) -> Task<EmbeddingCache, any Error> in
-      if let task { return task }
+    let task = cacheState.withLock { (state: inout CacheSlot) -> Task<EmbeddingCache, any Error> in
+      // If a task exists (loading or completed), always return it —
+      // even if stale. We'll check staleness after the load finishes.
+      if let existing = state.task {
+        return existing
+      }
       let newTask = Task { try await loadCache() }
-      task = newTask
+      state.task = newTask
+      state.stale = false
       return newTask
     }
-    return try await task.value
+    
+    let result = try await task.value
+    
+    // After the load finishes, if we were marked stale during the load,
+    // clear the task so the *next* search triggers a fresh reload.
+    cacheState.withLock { (state: inout CacheSlot) in
+      if state.stale {
+        state.task = nil
+        state.stale = false
+      }
+    }
+    
+    return result
   }
   
   private nonisolated func loadCache() async throws -> EmbeddingCache {
@@ -327,6 +332,11 @@ final class SearchService: @unchecked Sendable {
 }
 
 // MARK: - Internal types
+
+private struct CacheSlot: @unchecked Sendable {
+  var task: Task<EmbeddingCache, any Error>?
+  var stale = false
+}
 
 private struct EmbeddingCache: Sendable {
   let embeddings: [Float]  // Contiguous N × dims buffer

--- a/Sharkfin/Search/SearchViewModel.swift
+++ b/Sharkfin/Search/SearchViewModel.swift
@@ -51,6 +51,7 @@ final class SearchViewModel {
   private let database: AppDatabase
   private let modelManager: CLIPModelManager
   private var searchService: SearchService?
+  private var searchServiceTask: Task<SearchService, any Error>?
   private var searchTask: Task<Void, Never>?
   
   init(database: AppDatabase, modelManager: CLIPModelManager) {
@@ -62,7 +63,10 @@ final class SearchViewModel {
     let types = (try? await database.fetchAvailableFileTypes()) ?? []
     availableFileTypes = types
     // Remove any selected types that are no longer available
-    filters.fileTypes.formIntersection(availableFileTypes)
+    let pruned = filters.fileTypes.intersection(availableFileTypes)
+    if pruned != filters.fileTypes {
+      filters.fileTypes = pruned
+    }
   }
   
   func filtersChanged() {
@@ -116,6 +120,7 @@ final class SearchViewModel {
     let currentFilters = filters
     do {
       let service = try await getOrCreateSearchService()
+      guard !Task.isCancelled else { return }
       let searchResults = try await Task.detached(priority: .userInitiated) {
         try await service.search(query: query, filters: currentFilters)
       }.value
@@ -134,17 +139,26 @@ final class SearchViewModel {
   
   private func getOrCreateSearchService() async throws -> SearchService {
     if let existing = searchService { return existing }
-    guard let modelURL = modelManager.textModelURL,
-          let tokenizerURL = modelManager.textTokenizerFolderURL
-    else {
-      throw CLIPError.modelNotReady
+    if let task = searchServiceTask { return try await task.value }
+    
+    let db = database
+    let mm = modelManager
+    let task = Task<SearchService, any Error> {
+      guard let modelURL = mm.textModelURL,
+            let tokenizerURL = mm.textTokenizerFolderURL
+      else {
+        throw CLIPError.modelNotReady
+      }
+      let encoder = try await CLIPTextEncoder(
+        modelPath: modelURL,
+        tokenizerFolder: tokenizerURL
+      )
+      return SearchService(database: db, textEncoder: encoder)
     }
-    let encoder = try await CLIPTextEncoder(
-      modelPath: modelURL,
-      tokenizerFolder: tokenizerURL
-    )
-    let service = SearchService(database: database, textEncoder: encoder)
+    searchServiceTask = task
+    let service = try await task.value
     searchService = service
+    searchServiceTask = nil
     return service
   }
 }


### PR DESCRIPTION
I noticed memory usage was very high (re #22). This was due to concurrent calls to `getCache` which was causing a classic TOCTOU race condition: multiple concurrent search processes were trying to access the cache, noticed it was empty, and then loaded it in memory again.

The fix here was to update `getCache` internals to use a `cacheTask` to point to one source of truth for the cached embeddings.

## Result

Initial memory on app launch:

<img width="2076" height="1322" alt="Image" src="https://github.com/user-attachments/assets/6c06caf9-f758-442b-b4db-467f0c47f7d2" />

After performing the first search:

<img width="2076" height="1322" alt="CleanShot 2026-04-10 at 18 01 51@2x" src="https://github.com/user-attachments/assets/7f24b56c-ee0c-4035-ad2c-d3f8c93a3cc0" />

Lower now, but nothing like a crazy reduction. I'll need to expand this to prevent insane memory usage.

Search performance remains impressive at 33 milliseconds total:

```
2026-04-10 15:07:56.372 [DEBUG] [Search] "animal" — 18439 embeddings, 18378 results
  Text encode:  0.005953958 seconds
  Cache load:   3.041e-06 seconds
  vDSP_mmul:    0.000242 seconds
  Filter+sort:  0.027773416 seconds
  Total:        0.033974875 seconds
```