### PR TITLE
Support different CLIP model packages

### DIFF
--- a/Sharkfin/CLIP/CLIPImageEncoder.swift
+++ b/Sharkfin/CLIP/CLIPImageEncoder.swift
@@ -15,10 +15,14 @@ final class CLIPImageEncoder: @unchecked Sendable {
     let env = try ORTEnv(loggingLevel: .warning)
     
     let options = try ORTSessionOptions()
-    // Use CoreML execution provider for GPU acceleration
-    try? options.appendCoreMLExecutionProvider(
-      with: ORTCoreMLExecutionProviderOptions()
-    )
+    // Use CoreML execution provider for GPU acceleration.
+    // Larger models (e.g. ViT-L/14) fail to load on the ANE,
+    // so exclude it for high-dimensional encoders.
+    let coreMLOptions = ORTCoreMLExecutionProviderOptions()
+    if embeddingDimension > 512 {
+      coreMLOptions.useCPUAndGPU = true
+    }
+    try? options.appendCoreMLExecutionProvider(with: coreMLOptions)
     
     self.session = try ORTSession(
       env: env,

--- a/Sharkfin/CLIP/CLIPImageEncoder.swift
+++ b/Sharkfin/CLIP/CLIPImageEncoder.swift
@@ -4,13 +4,14 @@ import OnnxRuntimeBindings
 /// Wraps the ONNX Runtime vision session for CLIP image encoding.
 final class CLIPImageEncoder: @unchecked Sendable {
   
-  /// Number of dimensions in a CLIP embedding vector.
-  nonisolated static let embeddingDimension = 512
+  /// Number of dimensions in the embedding vector for this encoder.
+  nonisolated let embeddingDimension: Int
   
   nonisolated(unsafe) private let session: ORTSession
   private nonisolated let outputName: String
   
-  nonisolated init(modelPath: URL) throws {
+  nonisolated init(modelPath: URL, embeddingDimension: Int = 512) throws {
+    self.embeddingDimension = embeddingDimension
     let env = try ORTEnv(loggingLevel: .warning)
     
     let options = try ORTSessionOptions()
@@ -58,8 +59,8 @@ final class CLIPImageEncoder: @unchecked Sendable {
     }
     
     // Take only the expected dims if output is larger
-    if embedding.count > Self.embeddingDimension {
-      embedding = Array(embedding.prefix(Self.embeddingDimension))
+    if embedding.count > embeddingDimension {
+      embedding = Array(embedding.prefix(embeddingDimension))
     }
     
     return Self.l2Normalize(embedding)

--- a/Sharkfin/CLIP/CLIPModelManager.swift
+++ b/Sharkfin/CLIP/CLIPModelManager.swift
@@ -12,7 +12,7 @@ enum ModelDownloadState: Equatable {
   case error(String)
 }
 
-// MARK: - Model Specification
+// MARK: - Model File Specification
 
 struct CLIPModelSpec: Identifiable {
   let id: String
@@ -36,34 +36,95 @@ struct CLIPModelSpec: Identifiable {
   }
 }
 
-extension CLIPModelSpec {
-  static let textEncoder = CLIPModelSpec(
-    id: "clip-vit-base-patch32-text-onnx",
-    displayName: "CLIP Text Encoder",
-    repoID: "xplato/clip-vit-base-patch32-text-onnx",
-    files: [
-      ModelFile(filename: "model.onnx", sizeBytes: 254_000_000),
-      ModelFile(filename: "tokenizer.json", sizeBytes: 2_220_000),
-      ModelFile(filename: "vocab.json", sizeBytes: 862_000),
-      ModelFile(filename: "merges.txt", sizeBytes: 525_000),
-      ModelFile(filename: "config.json", sizeBytes: 536),
-      ModelFile(filename: "tokenizer_config.json", sizeBytes: 705),
-      ModelFile(filename: "special_tokens_map.json", sizeBytes: 588),
-    ]
+// MARK: - Model Package
+
+/// A paired set of CLIP text + vision encoders at a specific model size.
+/// Each package produces embeddings of a fixed dimension and is identified
+/// by a stable `id` that gets stored alongside embeddings in the database.
+struct CLIPModelPackage: Identifiable {
+  let id: String
+  let displayName: String
+  let description: String
+  let embeddingDimension: Int
+  let textEncoder: CLIPModelSpec
+  let visionEncoder: CLIPModelSpec
+  
+  var totalSizeBytes: Int64 {
+    textEncoder.totalSizeBytes + visionEncoder.totalSizeBytes
+  }
+  
+  /// All individual model specs in this package.
+  var specs: [CLIPModelSpec] { [textEncoder, visionEncoder] }
+}
+
+extension CLIPModelPackage {
+  static let vitB32 = CLIPModelPackage(
+    id: "clip-vit-base-patch32",
+    displayName: "CLIP ViT-B/32",
+    description: "Smallest and fastest. Good for general use.",
+    embeddingDimension: 512,
+    textEncoder: CLIPModelSpec(
+      id: "clip-vit-base-patch32-text-onnx",
+      displayName: "Text Encoder",
+      repoID: "xplato/clip-vit-base-patch32-text-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 254_000_000),
+        .init(filename: "tokenizer.json", sizeBytes: 2_220_000),
+        .init(filename: "vocab.json", sizeBytes: 862_000),
+        .init(filename: "merges.txt", sizeBytes: 525_000),
+        .init(filename: "config.json", sizeBytes: 536),
+        .init(filename: "tokenizer_config.json", sizeBytes: 705),
+        .init(filename: "special_tokens_map.json", sizeBytes: 588),
+      ]
+    ),
+    visionEncoder: CLIPModelSpec(
+      id: "clip-vit-base-patch32-vision-onnx",
+      displayName: "Vision Encoder",
+      repoID: "xplato/clip-vit-base-patch32-vision-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 352_000_000),
+        .init(filename: "config.json", sizeBytes: 482),
+        .init(filename: "preprocessor_config.json", sizeBytes: 780),
+      ]
+    )
   )
   
-  static let visionEncoder = CLIPModelSpec(
-    id: "clip-vit-base-patch32-vision-onnx",
-    displayName: "CLIP Vision Encoder",
-    repoID: "xplato/clip-vit-base-patch32-vision-onnx",
-    files: [
-      ModelFile(filename: "model.onnx", sizeBytes: 352_000_000),
-      ModelFile(filename: "config.json", sizeBytes: 482),
-      ModelFile(filename: "preprocessor_config.json", sizeBytes: 780),
-    ]
+  static let vitB16 = CLIPModelPackage(
+    id: "clip-vit-base-patch16",
+    displayName: "CLIP ViT-B/16",
+    description: "Better detail recognition, same download size.",
+    embeddingDimension: 512,
+    textEncoder: CLIPModelSpec(
+      id: "clip-vit-base-patch16-text-onnx",
+      displayName: "Text Encoder",
+      repoID: "xplato/clip-vit-base-patch16-text-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 254_000_000),
+        .init(filename: "tokenizer.json", sizeBytes: 2_220_000),
+        .init(filename: "vocab.json", sizeBytes: 862_000),
+        .init(filename: "merges.txt", sizeBytes: 525_000),
+        .init(filename: "config.json", sizeBytes: 536),
+        .init(filename: "tokenizer_config.json", sizeBytes: 705),
+        .init(filename: "special_tokens_map.json", sizeBytes: 588),
+      ]
+    ),
+    visionEncoder: CLIPModelSpec(
+      id: "clip-vit-base-patch16-vision-onnx",
+      displayName: "Vision Encoder",
+      repoID: "xplato/clip-vit-base-patch16-vision-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 345_000_000),
+        .init(filename: "config.json", sizeBytes: 482),
+        .init(filename: "preprocessor_config.json", sizeBytes: 780),
+      ]
+    )
   )
   
-  static let all: [CLIPModelSpec] = [textEncoder, visionEncoder]
+  /// All available model packages, ordered from smallest to largest.
+  static let all: [CLIPModelPackage] = [vitB32, vitB16]
+  
+  /// The default package used when no preference has been set.
+  static let `default` = vitB32
 }
 
 // MARK: - Model Manager
@@ -71,6 +132,7 @@ extension CLIPModelSpec {
 @MainActor
 @Observable
 final class CLIPModelManager {
+  /// Download state for each individual model spec (keyed by spec ID).
   private(set) var modelStates: [String: ModelDownloadState] = [:]
   
   private var activeDownloads: [String: FileDownloader] = [:]
@@ -84,17 +146,98 @@ final class CLIPModelManager {
   }()
   
   init() {
+    self.activePackage = Self.loadActivePackage()
     try? fileManager.createDirectory(
       at: Self.modelsDirectoryURL,
       withIntermediateDirectories: true
     )
     cleanupTemporaryFiles()
-    for model in CLIPModelSpec.all {
-      modelStates[model.id] = checkDownloadStatus(for: model)
+    // Check download status for all specs across all packages
+    for package in CLIPModelPackage.all {
+      for spec in package.specs {
+        modelStates[spec.id] = checkDownloadStatus(for: spec)
+      }
     }
   }
   
-  // MARK: - Public API
+  // MARK: - Active Package
+  
+  /// The user's selected model package. Stored so @Observable can track changes.
+  private(set) var activePackage: CLIPModelPackage
+  
+  func setActivePackage(_ package: CLIPModelPackage) {
+    activePackage = package
+    UserDefaults.standard.set(package.id, forKey: StorageKey.activeModelPackage)
+    NotificationCenter.default.post(
+      name: .searchCacheDidInvalidate,
+      object: nil
+    )
+  }
+  
+  private static func loadActivePackage() -> CLIPModelPackage {
+    let storedId = UserDefaults.standard.string(
+      forKey: StorageKey.activeModelPackage
+    )
+    return CLIPModelPackage.all.first { $0.id == storedId } ?? .default
+  }
+  
+  // MARK: - Package-Level API
+  
+  /// Download all models in a package.
+  func downloadPackage(_ package: CLIPModelPackage) {
+    for spec in package.specs {
+      download(spec)
+    }
+  }
+  
+  /// Cancel all downloads in a package.
+  func cancelPackage(_ package: CLIPModelPackage) {
+    for spec in package.specs {
+      cancel(spec)
+    }
+  }
+  
+  /// Delete all model files in a package.
+  func deletePackage(_ package: CLIPModelPackage) {
+    for spec in package.specs {
+      delete(spec)
+    }
+  }
+  
+  /// Whether all models in a package are downloaded and ready.
+  func isPackageReady(_ package: CLIPModelPackage) -> Bool {
+    package.specs.allSatisfy { modelStates[$0.id] == .downloaded }
+  }
+  
+  /// Aggregate download state for a package.
+  func packageState(_ package: CLIPModelPackage) -> ModelDownloadState {
+    let states = package.specs.map { modelStates[$0.id] ?? .notDownloaded }
+    if states.allSatisfy({ $0 == .downloaded }) { return .downloaded }
+    if let error = states.first(where: {
+      if case .error = $0 { return true }; return false
+    }) { return error }
+    // If any spec is downloading, compute aggregate progress
+    let downloading = states.contains {
+      if case .downloading = $0 { return true }; return false
+    }
+    if downloading {
+      var totalBytes: Int64 = 0
+      var weightedProgress: Double = 0
+      for spec in package.specs {
+        totalBytes += spec.totalSizeBytes
+        if case .downloading(let p) = modelStates[spec.id] {
+          weightedProgress += p * Double(spec.totalSizeBytes)
+        } else if modelStates[spec.id] == .downloaded {
+          weightedProgress += Double(spec.totalSizeBytes)
+        }
+      }
+      let overall = totalBytes > 0 ? weightedProgress / Double(totalBytes) : 0
+      return .downloading(progress: overall)
+    }
+    return .notDownloaded
+  }
+  
+  // MARK: - Individual Spec API
   
   func download(_ model: CLIPModelSpec) {
     guard modelStates[model.id] != .downloading(progress: 0) else { return }
@@ -127,35 +270,34 @@ final class CLIPModelManager {
   
   // MARK: - Convenience Accessors
   
+  /// The text model URL for the active package, if downloaded.
   var textModelURL: URL? {
-    guard modelStates[CLIPModelSpec.textEncoder.id] == .downloaded else {
-      return nil
-    }
+    let spec = activePackage.textEncoder
+    guard modelStates[spec.id] == .downloaded else { return nil }
     return Self.modelsDirectoryURL
-      .appendingPathComponent(CLIPModelSpec.textEncoder.id)
+      .appendingPathComponent(spec.id)
       .appendingPathComponent("model.onnx")
   }
   
+  /// The tokenizer folder URL for the active package, if downloaded.
   var textTokenizerFolderURL: URL? {
-    guard modelStates[CLIPModelSpec.textEncoder.id] == .downloaded else {
-      return nil
-    }
-    return Self.modelsDirectoryURL
-      .appendingPathComponent(CLIPModelSpec.textEncoder.id)
+    let spec = activePackage.textEncoder
+    guard modelStates[spec.id] == .downloaded else { return nil }
+    return Self.modelsDirectoryURL.appendingPathComponent(spec.id)
   }
   
+  /// The vision model URL for the active package, if downloaded.
   var visionModelURL: URL? {
-    guard modelStates[CLIPModelSpec.visionEncoder.id] == .downloaded else {
-      return nil
-    }
+    let spec = activePackage.visionEncoder
+    guard modelStates[spec.id] == .downloaded else { return nil }
     return Self.modelsDirectoryURL
-      .appendingPathComponent(CLIPModelSpec.visionEncoder.id)
+      .appendingPathComponent(spec.id)
       .appendingPathComponent("model.onnx")
   }
   
+  /// Whether the active package is fully downloaded and ready.
   var isReady: Bool {
-    modelStates[CLIPModelSpec.textEncoder.id] == .downloaded
-    && modelStates[CLIPModelSpec.visionEncoder.id] == .downloaded
+    isPackageReady(activePackage)
   }
   
   // MARK: - Download Logic

--- a/Sharkfin/CLIP/CLIPModelManager.swift
+++ b/Sharkfin/CLIP/CLIPModelManager.swift
@@ -72,7 +72,6 @@ extension CLIPModelPackage {
         .init(filename: "tokenizer.json", sizeBytes: 2_220_000),
         .init(filename: "vocab.json", sizeBytes: 862_000),
         .init(filename: "merges.txt", sizeBytes: 525_000),
-        .init(filename: "config.json", sizeBytes: 536),
         .init(filename: "tokenizer_config.json", sizeBytes: 705),
         .init(filename: "special_tokens_map.json", sizeBytes: 588),
       ]
@@ -83,8 +82,6 @@ extension CLIPModelPackage {
       repoID: "xplato/clip-vit-base-patch32-vision-onnx",
       files: [
         .init(filename: "model.onnx", sizeBytes: 352_000_000),
-        .init(filename: "config.json", sizeBytes: 482),
-        .init(filename: "preprocessor_config.json", sizeBytes: 780),
       ]
     )
   )
@@ -103,7 +100,6 @@ extension CLIPModelPackage {
         .init(filename: "tokenizer.json", sizeBytes: 2_220_000),
         .init(filename: "vocab.json", sizeBytes: 862_000),
         .init(filename: "merges.txt", sizeBytes: 525_000),
-        .init(filename: "config.json", sizeBytes: 536),
         .init(filename: "tokenizer_config.json", sizeBytes: 705),
         .init(filename: "special_tokens_map.json", sizeBytes: 588),
       ]
@@ -114,14 +110,40 @@ extension CLIPModelPackage {
       repoID: "xplato/clip-vit-base-patch16-vision-onnx",
       files: [
         .init(filename: "model.onnx", sizeBytes: 345_000_000),
-        .init(filename: "config.json", sizeBytes: 482),
-        .init(filename: "preprocessor_config.json", sizeBytes: 780),
+      ]
+    )
+  )
+  
+  static let vitL14 = CLIPModelPackage(
+    id: "clip-vit-large-patch14",
+    displayName: "CLIP ViT-L/14",
+    description: "Best quality, larger download.",
+    embeddingDimension: 768,
+    textEncoder: CLIPModelSpec(
+      id: "clip-vit-large-patch14-text-onnx",
+      displayName: "Text Encoder",
+      repoID: "xplato/clip-vit-large-patch14-text-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 495_000_000),
+        .init(filename: "tokenizer.json", sizeBytes: 2_220_000),
+        .init(filename: "vocab.json", sizeBytes: 862_000),
+        .init(filename: "merges.txt", sizeBytes: 525_000),
+        .init(filename: "tokenizer_config.json", sizeBytes: 705),
+        .init(filename: "special_tokens_map.json", sizeBytes: 588),
+      ]
+    ),
+    visionEncoder: CLIPModelSpec(
+      id: "clip-vit-large-patch14-vision-onnx",
+      displayName: "Vision Encoder",
+      repoID: "xplato/clip-vit-large-patch14-vision-onnx",
+      files: [
+        .init(filename: "model.onnx", sizeBytes: 1_220_000_000),
       ]
     )
   )
   
   /// All available model packages, ordered from smallest to largest.
-  static let all: [CLIPModelPackage] = [vitB32, vitB16]
+  static let all: [CLIPModelPackage] = [vitB32, vitB16, vitL14]
   
   /// The default package used when no preference has been set.
   static let `default` = vitB32

--- a/Sharkfin/CLIP/CLIPModelManager.swift
+++ b/Sharkfin/CLIP/CLIPModelManager.swift
@@ -1,6 +1,7 @@
 // TODO: rebuild this whole thing smh
 
 import Foundation
+import GRDB
 import Observation
 
 // MARK: - Model Download State
@@ -219,11 +220,21 @@ final class CLIPModelManager {
     }
   }
   
-  /// Delete all model files in a package.
+  /// Delete all model files in a package and remove its embeddings from the DB.
   func deletePackage(_ package: CLIPModelPackage) {
     for spec in package.specs {
       delete(spec)
     }
+    try? AppDatabase.shared.dbQueue.write { db in
+      try db.execute(
+        sql: "DELETE FROM fileEmbeddings WHERE modelId = ?",
+        arguments: [package.id]
+      )
+    }
+    NotificationCenter.default.post(
+      name: .searchCacheDidInvalidate,
+      object: nil
+    )
   }
   
   /// Whether all models in a package are downloaded and ready.

--- a/Sharkfin/CLIP/CLIPTextEncoder.swift
+++ b/Sharkfin/CLIP/CLIPTextEncoder.swift
@@ -14,8 +14,14 @@ final class CLIPTextEncoder: @unchecked Sendable, TextEncoding {
   private nonisolated let tokenizer: any Tokenizer
   private nonisolated let outputName: String
   private nonisolated let maxLength = 77
+  private nonisolated let embeddingDimension: Int
   
-  nonisolated init(modelPath: URL, tokenizerFolder: URL) async throws {
+  nonisolated init(
+    modelPath: URL,
+    tokenizerFolder: URL,
+    embeddingDimension: Int = 512
+  ) async throws {
+    self.embeddingDimension = embeddingDimension
     let env = try ORTEnv(loggingLevel: .warning)
     
     // CPU-only for text model (small, fast, avoids CoreML dynamic shape issues)
@@ -118,8 +124,8 @@ final class CLIPTextEncoder: @unchecked Sendable, TextEncoding {
       Array(buffer.bindMemory(to: Float.self))
     }
     
-    if embedding.count > CLIPImageEncoder.embeddingDimension {
-      embedding = Array(embedding.prefix(CLIPImageEncoder.embeddingDimension))
+    if embedding.count > embeddingDimension {
+      embedding = Array(embedding.prefix(embeddingDimension))
     }
     
     return CLIPImageEncoder.l2Normalize(embedding)

--- a/Sharkfin/Database/AppDatabase.swift
+++ b/Sharkfin/Database/AppDatabase.swift
@@ -97,6 +97,26 @@ final class AppDatabase: Sendable {
       )
     }
     
+    migrator.registerMigration("v3-multi-model-embeddings") { db in
+      // Recreate fileEmbeddings with composite primary key (fileId, modelId)
+      // so each file can store one embedding per model package.
+      try db.create(table: "fileEmbeddings_new") { t in
+        t.column("fileId", .integer)
+          .notNull()
+          .references("files", onDelete: .cascade)
+        t.column("embedding", .blob).notNull()
+        t.column("modelId", .text).notNull()
+        t.primaryKey(["fileId", "modelId"])
+      }
+      try db.execute(sql: """
+        INSERT INTO fileEmbeddings_new (fileId, embedding, modelId)
+        SELECT fileId, embedding, modelId FROM fileEmbeddings
+        """)
+      try db.drop(table: "fileEmbeddings")
+      try db.rename(table: "fileEmbeddings_new", to: "fileEmbeddings")
+      try db.create(indexOn: "fileEmbeddings", columns: ["modelId"])
+    }
+    
     return migrator
   }
   

--- a/Sharkfin/Database/AppDatabase.swift
+++ b/Sharkfin/Database/AppDatabase.swift
@@ -83,6 +83,20 @@ final class AppDatabase: Sendable {
       try db.create(indexOn: "fileMetadata", columns: ["key"])
     }
     
+    migrator.registerMigration("v2-model-tracking") { db in
+      // Track which model package produced each embedding so we can
+      // detect stale embeddings when the user switches models.
+      try db.alter(table: "fileEmbeddings") { t in
+        t.add(column: "modelId", .text)
+          .notNull()
+          .defaults(to: "clip-vit-base-patch32")
+      }
+      try db.create(
+        indexOn: "fileEmbeddings",
+        columns: ["modelId"]
+      )
+    }
+    
     return migrator
   }
   

--- a/Sharkfin/Database/AppDatabase.swift
+++ b/Sharkfin/Database/AppDatabase.swift
@@ -46,12 +46,16 @@ final class AppDatabase: Sendable {
         t.column("thumbnailPath", .text)
       }
       
-      // file_embeddings
+      // file_embeddings (one embedding per file per model)
       try db.create(table: "fileEmbeddings") { t in
-        t.primaryKey("fileId", .integer)
+        t.column("fileId", .integer)
+          .notNull()
           .references("files", onDelete: .cascade)
         t.column("embedding", .blob).notNull()
+        t.column("modelId", .text).notNull()
+        t.primaryKey(["fileId", "modelId"])
       }
+      try db.create(indexOn: "fileEmbeddings", columns: ["modelId"])
       
       // file_metadata
       try db.create(table: "fileMetadata") { t in
@@ -81,40 +85,6 @@ final class AppDatabase: Sendable {
       try db.create(indexOn: "files", columns: ["contentHash"])
       try db.create(indexOn: "fileMetadata", columns: ["fileId"])
       try db.create(indexOn: "fileMetadata", columns: ["key"])
-    }
-    
-    migrator.registerMigration("v2-model-tracking") { db in
-      // Track which model package produced each embedding so we can
-      // detect stale embeddings when the user switches models.
-      try db.alter(table: "fileEmbeddings") { t in
-        t.add(column: "modelId", .text)
-          .notNull()
-          .defaults(to: "clip-vit-base-patch32")
-      }
-      try db.create(
-        indexOn: "fileEmbeddings",
-        columns: ["modelId"]
-      )
-    }
-    
-    migrator.registerMigration("v3-multi-model-embeddings") { db in
-      // Recreate fileEmbeddings with composite primary key (fileId, modelId)
-      // so each file can store one embedding per model package.
-      try db.create(table: "fileEmbeddings_new") { t in
-        t.column("fileId", .integer)
-          .notNull()
-          .references("files", onDelete: .cascade)
-        t.column("embedding", .blob).notNull()
-        t.column("modelId", .text).notNull()
-        t.primaryKey(["fileId", "modelId"])
-      }
-      try db.execute(sql: """
-        INSERT INTO fileEmbeddings_new (fileId, embedding, modelId)
-        SELECT fileId, embedding, modelId FROM fileEmbeddings
-        """)
-      try db.drop(table: "fileEmbeddings")
-      try db.rename(table: "fileEmbeddings_new", to: "fileEmbeddings")
-      try db.create(indexOn: "fileEmbeddings", columns: ["modelId"])
     }
     
     return migrator

--- a/Sharkfin/Database/Models/FileEmbedding.swift
+++ b/Sharkfin/Database/Models/FileEmbedding.swift
@@ -4,6 +4,7 @@ import GRDB
 nonisolated struct FileEmbedding: Codable, Identifiable, Sendable {
   var fileId: Int64
   var embedding: Data
+  var modelId: String
   
   var id: Int64 { fileId }
 }

--- a/Sharkfin/Database/Models/FileEmbedding.swift
+++ b/Sharkfin/Database/Models/FileEmbedding.swift
@@ -1,12 +1,10 @@
 import Foundation
 import GRDB
 
-nonisolated struct FileEmbedding: Codable, Identifiable, Sendable {
+nonisolated struct FileEmbedding: Codable, Sendable {
   var fileId: Int64
   var embedding: Data
   var modelId: String
-  
-  var id: Int64 { fileId }
 }
 
 nonisolated extension FileEmbedding: FetchableRecord, PersistableRecord {

--- a/Sharkfin/Indexing/IndexingService.swift
+++ b/Sharkfin/Indexing/IndexingService.swift
@@ -177,31 +177,33 @@ final class IndexingService {
     
     // Phase 2: Diff against all existing indexed files (across directories)
     // so we can detect overlapping files owned by a different directory
-    // and files whose embeddings were produced by a different model.
+    // and files that lack an embedding for the active model.
     let activeModelId = modelPackage.id
-    let (existingDates, existingOwners, existingModelIds) = try await database.dbQueue.read {
-      db -> ([String: Date], [String: Int64], [String: String?]) in
+    let (existingFiles, existingOwners) = try await database.dbQueue.read {
+      db -> ([String: (date: Date, fileId: Int64, hasActiveEmbed: Bool)], [String: Int64]) in
       let rows = try Row.fetchAll(
         db,
         sql: """
-          SELECT f.path, f.modifiedAt, f.directoryId, e.modelId
+          SELECT f.id AS fileId, f.path, f.modifiedAt, f.directoryId,
+                 EXISTS(SELECT 1 FROM fileEmbeddings e
+                        WHERE e.fileId = f.id AND e.modelId = ?) AS hasActiveEmbed
           FROM files f
-          LEFT JOIN fileEmbeddings e ON e.fileId = f.id
-          """
+          """,
+        arguments: [activeModelId]
       )
-      var dates: [String: Date] = [:]
+      var files: [String: (date: Date, fileId: Int64, hasActiveEmbed: Bool)] = [:]
       var owners: [String: Int64] = [:]
-      var modelIds: [String: String?] = [:]
       for row in rows {
         if let path: String = row["path"],
            let date: Date = row["modifiedAt"],
-           let ownerId: Int64 = row["directoryId"] {
-          dates[path] = date
+           let ownerId: Int64 = row["directoryId"],
+           let fileId: Int64 = row["fileId"] {
+          let hasEmbed: Bool = row["hasActiveEmbed"]
+          files[path] = (date: date, fileId: fileId, hasActiveEmbed: hasEmbed)
           owners[path] = ownerId
-          modelIds[path] = row["modelId"] as String?
         }
       }
-      return (dates, owners, modelIds)
+      return (files, owners)
     }
     
     // Clean up records for files owned by this directory that no longer exist on disk
@@ -230,31 +232,31 @@ final class IndexingService {
     }
     
     // Categorize scanned files into four tiers:
-    // 1. New or modified → full processing pipeline
-    // 2. Embedding produced by a different model → re-index
+    // 1. New or modified → full processing pipeline (deletes old file + all embeddings)
+    // 2. Unchanged but missing embedding for active model → generate embedding only
     // 3. Unchanged but owned by a removed/disabled directory → cheap reassignment
-    // 4. Unchanged and already owned by this or another active directory → skip
+    // 4. Unchanged with active-model embedding → skip
     var filesToProcess: [QuickScannedFile] = []
+    var filesToEmbed: [(file: QuickScannedFile, fileId: Int64)] = []
     var pathsToReassign: [String] = []
     
     for file in allFiles {
-      guard let existingDate = existingDates[file.url.path] else {
+      guard let existing = existingFiles[file.url.path] else {
         filesToProcess.append(file)
         continue
       }
       // The database stores dates as text with millisecond precision, so the
       // round-tripped date loses sub-millisecond information. Use a small
       // tolerance to avoid false positives from that truncation.
-      let isModified = file.modifiedAt.timeIntervalSince(existingDate) > 1.0
-      let embeddingModelId = existingModelIds[file.url.path] ?? nil
-      let needsReEmbed = embeddingModelId != activeModelId
+      let isModified = file.modifiedAt.timeIntervalSince(existing.date) > 1.0
       let currentOwner = existingOwners[file.url.path]
       let ownedByOther = currentOwner != dirId
       
-      if isModified || needsReEmbed {
+      if isModified {
         filesToProcess.append(file)
+      } else if !existing.hasActiveEmbed {
+        filesToEmbed.append((file: file, fileId: existing.fileId))
       } else if ownedByOther, let owner = currentOwner, !enabledDirIds.contains(owner) {
-        // Only reassign if the current owner is no longer active
         pathsToReassign.append(file.url.path)
       }
     }
@@ -276,7 +278,7 @@ final class IndexingService {
       }
     }
     
-    if filesToProcess.isEmpty {
+    if filesToProcess.isEmpty && filesToEmbed.isEmpty {
       try await database.dbQueue.write { db in
         if var dir = try SharkfinDirectory.fetchOne(db, id: dirId) {
           dir.lastIndexedAt = Date()
@@ -288,32 +290,66 @@ final class IndexingService {
     }
     
     // Phase 3: Process files with bounded concurrency
-    let total = filesToProcess.count
+    let total = filesToProcess.count + filesToEmbed.count
     onProgress(IndexingProgress(phase: .indexing, total: total))
     
     let maxConcurrency = 8
     var processed = 0
     
+    // Combine both queues into a single work list with a tag
+    // to distinguish full-process from embedding-only items.
+    enum WorkItem {
+      case full(QuickScannedFile)
+      case embedOnly(file: QuickScannedFile, fileId: Int64)
+      
+      var filename: String {
+        switch self {
+        case .full(let f): f.filename
+        case .embedOnly(let f, _): f.filename
+        }
+      }
+    }
+    
+    var workItems: [WorkItem] = filesToProcess.map { .full($0) }
+    workItems += filesToEmbed.map { .embedOnly(file: $0.file, fileId: $0.fileId) }
+    
     await withTaskGroup(of: String.self) { group in
       var index = 0
       
-      // Seed initial batch
-      while index < min(maxConcurrency, filesToProcess.count) {
-        let file = filesToProcess[index]
-        index += 1
-        group.addTask {
-          Self.processFile(
-            file,
-            directoryId: dirId,
-            encoder: encoder,
-            modelId: activeModelId,
-            database: database
-          )
-          return file.filename
+      func enqueue(_ item: WorkItem, in group: inout TaskGroup<String>) {
+        switch item {
+        case .full(let file):
+          group.addTask {
+            Self.processFile(
+              file,
+              directoryId: dirId,
+              encoder: encoder,
+              modelId: activeModelId,
+              database: database
+            )
+            return file.filename
+          }
+        case .embedOnly(let file, let fileId):
+          group.addTask {
+            Self.addEmbedding(
+              for: file,
+              fileId: fileId,
+              encoder: encoder,
+              modelId: activeModelId,
+              database: database
+            )
+            return file.filename
+          }
         }
       }
       
-      // As each task completes, enqueue the next file
+      // Seed initial batch
+      while index < min(maxConcurrency, workItems.count) {
+        enqueue(workItems[index], in: &group)
+        index += 1
+      }
+      
+      // As each task completes, enqueue the next item
       for await filename in group {
         if Task.isCancelled { break }
         processed += 1
@@ -326,19 +362,9 @@ final class IndexingService {
           )
         )
         
-        if index < filesToProcess.count {
-          let file = filesToProcess[index]
+        if index < workItems.count {
+          enqueue(workItems[index], in: &group)
           index += 1
-          group.addTask {
-            Self.processFile(
-              file,
-              directoryId: dirId,
-              encoder: encoder,
-              modelId: activeModelId,
-              database: database
-            )
-            return file.filename
-          }
         }
       }
     }
@@ -474,6 +500,60 @@ final class IndexingService {
     } catch {
       LoggingService.shared.info(
         "Failed to index \(file.filename): \(error)",
+        category: "Indexing"
+      )
+    }
+  }
+  
+  // MARK: - Embedding-Only Processing
+  
+  /// Generates and inserts an embedding for an existing file record.
+  /// Used when the file content hasn't changed but an embedding for the
+  /// active model doesn't exist yet.
+  private nonisolated static func addEmbedding(
+    for file: QuickScannedFile,
+    fileId: Int64,
+    encoder: CLIPImageEncoder,
+    modelId: String,
+    database: AppDatabase
+  ) {
+    do {
+      guard let image = NSImage(contentsOf: file.url) else { return }
+      
+      let maxDim: CGFloat = 4096
+      let finalImage: NSImage
+      if image.size.width > maxDim || image.size.height > maxDim {
+        let scale = min(maxDim / image.size.width, maxDim / image.size.height)
+        let newSize = NSSize(
+          width: image.size.width * scale,
+          height: image.size.height * scale
+        )
+        finalImage = NSImage(size: newSize)
+        finalImage.lockFocus()
+        image.draw(in: NSRect(origin: .zero, size: newSize))
+        finalImage.unlockFocus()
+      } else {
+        finalImage = image
+      }
+      
+      guard let tensorData = ImagePreprocessor.preprocess(finalImage) else {
+        return
+      }
+      let embedding = try encoder.encode(pixelValues: tensorData)
+      let embeddingData = embedding.withUnsafeBufferPointer { Data(buffer: $0) }
+      
+      try database.dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT OR REPLACE INTO fileEmbeddings (fileId, embedding, modelId)
+            VALUES (?, ?, ?)
+            """,
+          arguments: [fileId, embeddingData, modelId]
+        )
+      }
+    } catch {
+      LoggingService.shared.info(
+        "Failed to add embedding for \(file.filename): \(error)",
         category: "Indexing"
       )
     }

--- a/Sharkfin/Indexing/IndexingService.swift
+++ b/Sharkfin/Indexing/IndexingService.swift
@@ -71,6 +71,7 @@ final class IndexingService {
     
     let db = database
     activeTasks[dirId] = Task.detached { [weak self] in
+      let startTime = ContinuousClock.now
       do {
         try await Self.performIndexing(
           dirId: dirId,
@@ -84,6 +85,11 @@ final class IndexingService {
             service?.progressByDirectory[dirId] = progress
           }
         }
+        let elapsed = ContinuousClock.now - startTime
+        LoggingService.shared.debug(
+          "Directory \(dirId) indexed in \(elapsed)",
+          category: "Indexing"
+        )
       } catch is CancellationError {
         let service = self
         await MainActor.run {

--- a/Sharkfin/Indexing/IndexingService.swift
+++ b/Sharkfin/Indexing/IndexingService.swift
@@ -65,6 +65,8 @@ final class IndexingService {
       return
     }
     
+    let activePackage = modelManager.activePackage
+    
     progressByDirectory[dirId] = IndexingProgress(phase: .scanning)
     
     let db = database
@@ -74,6 +76,7 @@ final class IndexingService {
           dirId: dirId,
           bookmark: bookmark,
           visionModelURL: visionModelURL,
+          modelPackage: activePackage,
           database: db
         ) { [weak self] progress in
           let service = self
@@ -122,6 +125,7 @@ final class IndexingService {
     dirId: Int64,
     bookmark: Data,
     visionModelURL: URL,
+    modelPackage: CLIPModelPackage,
     database: AppDatabase,
     onProgress: @Sendable @escaping (IndexingProgress) -> Void
   ) async throws {
@@ -137,7 +141,10 @@ final class IndexingService {
     defer { url.stopAccessingSecurityScopedResource() }
     
     // Create CLIP encoder (off main thread — model loading can be slow)
-    let encoder = try CLIPImageEncoder(modelPath: visionModelURL)
+    let encoder = try CLIPImageEncoder(
+      modelPath: visionModelURL,
+      embeddingDimension: modelPackage.embeddingDimension
+    )
     
     // Phase 1: Quick scan — enumerate files without hashing
     onProgress(IndexingProgress(phase: .scanning))
@@ -163,23 +170,32 @@ final class IndexingService {
     try Task.checkCancellation()
     
     // Phase 2: Diff against all existing indexed files (across directories)
-    // so we can detect overlapping files owned by a different directory.
-    let (existingDates, existingOwners) = try await database.dbQueue.read { db -> ([String: Date], [String: Int64]) in
+    // so we can detect overlapping files owned by a different directory
+    // and files whose embeddings were produced by a different model.
+    let activeModelId = modelPackage.id
+    let (existingDates, existingOwners, existingModelIds) = try await database.dbQueue.read {
+      db -> ([String: Date], [String: Int64], [String: String?]) in
       let rows = try Row.fetchAll(
         db,
-        sql: "SELECT path, modifiedAt, directoryId FROM files"
+        sql: """
+          SELECT f.path, f.modifiedAt, f.directoryId, e.modelId
+          FROM files f
+          LEFT JOIN fileEmbeddings e ON e.fileId = f.id
+          """
       )
       var dates: [String: Date] = [:]
       var owners: [String: Int64] = [:]
+      var modelIds: [String: String?] = [:]
       for row in rows {
         if let path: String = row["path"],
            let date: Date = row["modifiedAt"],
            let ownerId: Int64 = row["directoryId"] {
           dates[path] = date
           owners[path] = ownerId
+          modelIds[path] = row["modelId"] as String?
         }
       }
-      return (dates, owners)
+      return (dates, owners, modelIds)
     }
     
     // Clean up records for files owned by this directory that no longer exist on disk
@@ -207,10 +223,11 @@ final class IndexingService {
       return Set(ids)
     }
     
-    // Categorize scanned files into three tiers:
+    // Categorize scanned files into four tiers:
     // 1. New or modified → full processing pipeline
-    // 2. Unchanged but owned by a removed/disabled directory → cheap reassignment
-    // 3. Unchanged and already owned by this or another active directory → skip
+    // 2. Embedding produced by a different model → re-index
+    // 3. Unchanged but owned by a removed/disabled directory → cheap reassignment
+    // 4. Unchanged and already owned by this or another active directory → skip
     var filesToProcess: [QuickScannedFile] = []
     var pathsToReassign: [String] = []
     
@@ -223,10 +240,12 @@ final class IndexingService {
       // round-tripped date loses sub-millisecond information. Use a small
       // tolerance to avoid false positives from that truncation.
       let isModified = file.modifiedAt.timeIntervalSince(existingDate) > 1.0
+      let embeddingModelId = existingModelIds[file.url.path] ?? nil
+      let needsReEmbed = embeddingModelId != activeModelId
       let currentOwner = existingOwners[file.url.path]
       let ownedByOther = currentOwner != dirId
       
-      if isModified {
+      if isModified || needsReEmbed {
         filesToProcess.append(file)
       } else if ownedByOther, let owner = currentOwner, !enabledDirIds.contains(owner) {
         // Only reassign if the current owner is no longer active
@@ -281,6 +300,7 @@ final class IndexingService {
             file,
             directoryId: dirId,
             encoder: encoder,
+            modelId: activeModelId,
             database: database
           )
           return file.filename
@@ -308,6 +328,7 @@ final class IndexingService {
               file,
               directoryId: dirId,
               encoder: encoder,
+              modelId: activeModelId,
               database: database
             )
             return file.filename
@@ -347,6 +368,7 @@ final class IndexingService {
     _ file: QuickScannedFile,
     directoryId: Int64,
     encoder: CLIPImageEncoder,
+    modelId: String,
     database: AppDatabase
   ) {
     do {
@@ -438,7 +460,8 @@ final class IndexingService {
         guard let fileId = indexedFile.id else { return }
         let fileEmbedding = FileEmbedding(
           fileId: fileId,
-          embedding: embeddingData
+          embedding: embeddingData,
+          modelId: modelId
         )
         try fileEmbedding.insert(db)
       }

--- a/Sharkfin/Onboarding/ModelsStep.swift
+++ b/Sharkfin/Onboarding/ModelsStep.swift
@@ -5,26 +5,26 @@ struct ModelsStep: View {
   var onContinue: () -> Void
   var onSkip: () -> Void
   
+  private var activePackage: CLIPModelPackage {
+    modelManager.activePackage
+  }
+  
   private var allDownloaded: Bool {
     modelManager.isReady
   }
   
   private var isDownloading: Bool {
-    CLIPModelSpec.all.contains { model in
-      if case .downloading = modelManager.modelStates[model.id] ?? .notDownloaded {
-        return true
-      }
-      return false
+    if case .downloading = modelManager.packageState(activePackage) {
+      return true
     }
+    return false
   }
   
   private var hasError: Bool {
-    CLIPModelSpec.all.contains { model in
-      if case .error = modelManager.modelStates[model.id] ?? .notDownloaded {
-        return true
-      }
-      return false
+    if case .error = modelManager.packageState(activePackage) {
+      return true
     }
+    return false
   }
   
   var body: some View {
@@ -46,8 +46,8 @@ struct ModelsStep: View {
       Spacer().frame(height: 24)
       
       VStack(spacing: 12) {
-        ForEach(CLIPModelSpec.all) { model in
-          OnboardingModelRow(model: model, modelManager: modelManager)
+        ForEach(activePackage.specs) { spec in
+          OnboardingModelRow(spec: spec, modelManager: modelManager)
         }
       }
       .padding(.horizontal, 30)
@@ -109,16 +109,16 @@ struct ModelsStep: View {
 // MARK: - Onboarding Model Row
 
 private struct OnboardingModelRow: View {
-  let model: CLIPModelSpec
+  let spec: CLIPModelSpec
   let modelManager: CLIPModelManager
   
   private var state: ModelDownloadState {
-    modelManager.modelStates[model.id] ?? .notDownloaded
+    modelManager.modelStates[spec.id] ?? .notDownloaded
   }
   
   private var formattedSize: String {
     ByteCountFormatter.string(
-      fromByteCount: model.totalSizeBytes,
+      fromByteCount: spec.totalSizeBytes,
       countStyle: .file
     )
   }
@@ -131,7 +131,7 @@ private struct OnboardingModelRow: View {
         .frame(width: 24)
       
       VStack(alignment: .leading, spacing: 2) {
-        Text(model.displayName)
+        Text(spec.displayName)
           .font(.callout)
           .fontWeight(.medium)
         Text(formattedSize)
@@ -171,7 +171,7 @@ private struct OnboardingModelRow: View {
     switch state {
     case .notDownloaded:
       Button("Download") {
-        modelManager.download(model)
+        modelManager.download(spec)
       }
       .controlSize(.small)
       
@@ -185,7 +185,7 @@ private struct OnboardingModelRow: View {
           .foregroundStyle(.secondary)
           .monospacedDigit()
         Button {
-          modelManager.cancel(model)
+          modelManager.cancel(spec)
         } label: {
           Image(systemName: "xmark.circle")
         }
@@ -206,7 +206,7 @@ private struct OnboardingModelRow: View {
           .lineLimit(1)
           .frame(maxWidth: 100, alignment: .trailing)
         Button("Retry") {
-          modelManager.retry(model)
+          modelManager.retry(spec)
         }
         .controlSize(.small)
       }

--- a/Sharkfin/Search/SearchService.swift
+++ b/Sharkfin/Search/SearchService.swift
@@ -17,6 +17,7 @@ final class SearchService: @unchecked Sendable {
   
   private let database: AppDatabase
   private let textEncoder: any TextEncoding
+  private let modelId: String
   
   private nonisolated static let minRawScore: Float = 0.16
   private nonisolated static let scoreFloor: Float = 0.18
@@ -27,9 +28,10 @@ final class SearchService: @unchecked Sendable {
   private let cacheState = OSAllocatedUnfairLock(initialState: CacheSlot())
   private var notificationObserver: (any NSObjectProtocol)?
   
-  init(database: AppDatabase, textEncoder: any TextEncoding) {
+  init(database: AppDatabase, textEncoder: any TextEncoding, modelId: String) {
     self.database = database
     self.textEncoder = textEncoder
+    self.modelId = modelId
     
     notificationObserver = NotificationCenter.default.addObserver(
       forName: .searchCacheDidInvalidate,
@@ -239,13 +241,14 @@ final class SearchService: @unchecked Sendable {
   }
   
   private nonisolated func loadCache() async throws -> EmbeddingCache {
+    let activeModelId = modelId
     let sql = """
       SELECT e.fileId, e.embedding, f.filename, f.path, f.thumbnailPath,
              LOWER(f.fileExtension) AS fileExtension
       FROM fileEmbeddings e
       JOIN files f ON f.id = e.fileId
       JOIN directories d ON d.id = f.directoryId
-      WHERE d.enabled = 1
+      WHERE d.enabled = 1 AND e.modelId = ?
       """
     
     return try await database.dbQueue.read { db in
@@ -256,11 +259,16 @@ final class SearchService: @unchecked Sendable {
           FROM fileEmbeddings e
           JOIN files f ON f.id = e.fileId
           JOIN directories d ON d.id = f.directoryId
-          WHERE d.enabled = 1
-          """
+          WHERE d.enabled = 1 AND e.modelId = ?
+          """,
+        arguments: [activeModelId]
       ) ?? 0
       
-      let cursor = try EmbeddingRow.fetchCursor(db, sql: sql)
+      let cursor = try EmbeddingRow.fetchCursor(
+        db,
+        sql: sql,
+        arguments: [activeModelId]
+      )
       
       guard let firstRow = try cursor.next() else {
         return EmbeddingCache(

--- a/Sharkfin/Search/SearchService.swift
+++ b/Sharkfin/Search/SearchService.swift
@@ -322,7 +322,7 @@ final class SearchService: @unchecked Sendable {
       }
       
       LoggingService.shared.info(
-        "Cached \(fileIds.count) embeddings (\(dims) dims, \(embeddings.count * MemoryLayout<Float>.size / 1024)KB)",
+        "Cached \(fileIds.count) embeddings (\(dims) dims, \(embeddings.count * MemoryLayout<Float>.size / 1024)KB) for model \(activeModelId)",
         category: "Search"
       )
       return EmbeddingCache(

--- a/Sharkfin/Search/SearchViewModel.swift
+++ b/Sharkfin/Search/SearchViewModel.swift
@@ -54,6 +54,7 @@ final class SearchViewModel {
   private var searchServiceTask: Task<SearchService, any Error>?
   private var searchTask: Task<Void, Never>?
   private var idleUnloadTask: Task<Void, Never>?
+  private var cacheObserver: (any NSObjectProtocol)?
   
   /// How long to keep the text encoder in memory after the last search.
   /// Shorter on low-RAM machines to reduce memory pressure.
@@ -67,6 +68,20 @@ final class SearchViewModel {
   init(database: AppDatabase, modelManager: CLIPModelManager) {
     self.database = database
     self.modelManager = modelManager
+    
+    // When the active model changes (or embeddings are updated),
+    // drop the cached search service so it's recreated with the
+    // new model's encoder and ID on the next search.
+    cacheObserver = NotificationCenter.default.addObserver(
+      forName: .searchCacheDidInvalidate,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.searchService = nil
+        self?.searchServiceTask = nil
+      }
+    }
   }
   
   func loadAvailableFileTypes() async {

--- a/Sharkfin/Search/SearchViewModel.swift
+++ b/Sharkfin/Search/SearchViewModel.swift
@@ -54,7 +54,7 @@ final class SearchViewModel {
   private var searchServiceTask: Task<SearchService, any Error>?
   private var searchTask: Task<Void, Never>?
   private var idleUnloadTask: Task<Void, Never>?
-
+  
   /// How long to keep the text encoder in memory after the last search.
   /// Shorter on low-RAM machines to reduce memory pressure.
   private static let idleUnloadDelay: Duration = {
@@ -63,7 +63,7 @@ final class SearchViewModel {
     if ramGB <= 16 { return .seconds(600) }
     return .seconds(1800)
   }()
-
+  
   init(database: AppDatabase, modelManager: CLIPModelManager) {
     self.database = database
     self.modelManager = modelManager
@@ -147,7 +147,7 @@ final class SearchViewModel {
       state = .noResults
     }
   }
-
+  
   /// After a period of inactivity, release the text encoder and embedding
   /// cache to reclaim ~450MB. The next search will recreate them.
   private func scheduleIdleUnload() {
@@ -158,7 +158,7 @@ final class SearchViewModel {
       self?.unloadSearchService()
     }
   }
-
+  
   private func unloadSearchService() {
     searchService = nil
     searchServiceTask = nil
@@ -180,11 +180,17 @@ final class SearchViewModel {
       else {
         throw CLIPError.modelNotReady
       }
+      let activePackage = mm.activePackage
       let encoder = try await CLIPTextEncoder(
         modelPath: modelURL,
-        tokenizerFolder: tokenizerURL
+        tokenizerFolder: tokenizerURL,
+        embeddingDimension: activePackage.embeddingDimension
       )
-      return SearchService(database: db, textEncoder: encoder)
+      return SearchService(
+        database: db,
+        textEncoder: encoder,
+        modelId: activePackage.id
+      )
     }
     searchServiceTask = task
     let service = try await task.value

--- a/Sharkfin/Settings/GeneralSettingsView.swift
+++ b/Sharkfin/Settings/GeneralSettingsView.swift
@@ -59,8 +59,8 @@ struct GeneralSettingsView: View {
           "Models are downloaded from [huggingface.co/xplato](https://huggingface.co/xplato)"
         )
       ) {
-        ForEach(CLIPModelSpec.all) { model in
-          ModelRowView(model: model)
+        ForEach(CLIPModelPackage.all) { package in
+          ModelPackageRowView(package: package)
         }
       }
     }

--- a/Sharkfin/Settings/ModelRowView.swift
+++ b/Sharkfin/Settings/ModelRowView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct ModelPackageRowView: View {
   let package: CLIPModelPackage
   @Environment(CLIPModelManager.self) private var manager
+  @Environment(IndexingService.self) private var indexingService
+  @Environment(DirectoryStore.self) private var directoryStore
   @State private var showDeleteConfirmation = false
+  @State private var showActivateConfirmation = false
   
   private var state: ModelDownloadState {
     manager.packageState(package)
@@ -101,7 +104,21 @@ struct ModelPackageRowView: View {
       HStack(spacing: 8) {
         if !isActive {
           Button("Set Active") {
-            manager.activePackage = package
+            showActivateConfirmation = true
+          }
+          .confirmationDialog(
+            "Switch to \"\(package.displayName)\"?",
+            isPresented: $showActivateConfirmation,
+            titleVisibility: .visible
+          ) {
+            Button("Switch & Re-index") {
+              manager.setActivePackage(package)
+              indexingService.indexAllEnabled(from: directoryStore)
+            }
+          } message: {
+            Text(
+              "All indexed directories will be re-indexed with the new model. This may take a while depending on the number of files."
+            )
           }
         }
         Button(role: .destructive) {

--- a/Sharkfin/Settings/ModelRowView.swift
+++ b/Sharkfin/Settings/ModelRowView.swift
@@ -44,9 +44,14 @@ struct ModelPackageRowView: View {
               .clipShape(Capsule())
           }
         }
-        Text("\(package.description) — \(formattedSize)")
-          .font(.caption)
-          .foregroundStyle(.tertiary)
+        VStack(alignment: .leading, spacing: 0) {
+          Text("\(package.description)")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+          Text("\(formattedSize)")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+        }
       }
       
       Spacer()
@@ -103,7 +108,7 @@ struct ModelPackageRowView: View {
     case .downloaded:
       HStack(spacing: 8) {
         if !isActive {
-          Button("Set Active") {
+          Button("Use") {
             showActivateConfirmation = true
           }
           .confirmationDialog(

--- a/Sharkfin/Settings/ModelRowView.swift
+++ b/Sharkfin/Settings/ModelRowView.swift
@@ -116,13 +116,13 @@ struct ModelPackageRowView: View {
             isPresented: $showActivateConfirmation,
             titleVisibility: .visible
           ) {
-            Button("Switch & Re-index") {
+            Button("Switch & Index") {
               manager.setActivePackage(package)
               indexingService.indexAllEnabled(from: directoryStore)
             }
           } message: {
             Text(
-              "All indexed directories will be re-indexed with the new model. This may take a while depending on the number of files."
+              "Directories will be indexed with this model. Files already indexed with it will be skipped."
             )
           }
         }
@@ -142,7 +142,7 @@ struct ModelPackageRowView: View {
           }
         } message: {
           Text(
-            "The model files will be deleted. You can re-download them at any time."
+            "The model files and all embeddings created with this model will be deleted. You can re-download and re-index at any time."
           )
         }
       }

--- a/Sharkfin/Settings/ModelRowView.swift
+++ b/Sharkfin/Settings/ModelRowView.swift
@@ -1,17 +1,21 @@
 import SwiftUI
 
-struct ModelRowView: View {
-  let model: CLIPModelSpec
+struct ModelPackageRowView: View {
+  let package: CLIPModelPackage
   @Environment(CLIPModelManager.self) private var manager
   @State private var showDeleteConfirmation = false
   
   private var state: ModelDownloadState {
-    manager.modelStates[model.id] ?? .notDownloaded
+    manager.packageState(package)
+  }
+  
+  private var isActive: Bool {
+    manager.activePackage.id == package.id
   }
   
   private var formattedSize: String {
     ByteCountFormatter.string(
-      fromByteCount: model.totalSizeBytes,
+      fromByteCount: package.totalSizeBytes,
       countStyle: .file
     )
   }
@@ -23,9 +27,21 @@ struct ModelRowView: View {
         .font(.title3)
       
       VStack(alignment: .leading, spacing: 4) {
-        Text(model.displayName)
-          .fontWeight(.medium)
-        Text(formattedSize)
+        HStack(spacing: 6) {
+          Text(package.displayName)
+            .fontWeight(.medium)
+          if isActive && state == .downloaded {
+            Text("Active")
+              .font(.caption2)
+              .fontWeight(.medium)
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(.blue.opacity(0.15))
+              .foregroundStyle(.blue)
+              .clipShape(Capsule())
+          }
+        }
+        Text("\(package.description) — \(formattedSize)")
           .font(.caption)
           .foregroundStyle(.tertiary)
       }
@@ -61,7 +77,7 @@ struct ModelRowView: View {
     switch state {
     case .notDownloaded:
       Button("Download") {
-        manager.download(model)
+        manager.downloadPackage(package)
       }
       
     case .downloading(let progress):
@@ -74,7 +90,7 @@ struct ModelRowView: View {
           .foregroundStyle(.secondary)
           .monospacedDigit()
         Button {
-          manager.cancel(model)
+          manager.cancelPackage(package)
         } label: {
           Image(systemName: "xmark.circle")
         }
@@ -82,24 +98,31 @@ struct ModelRowView: View {
       }
       
     case .downloaded:
-      Button(role: .destructive) {
-        showDeleteConfirmation = true
-      } label: {
-        Image(systemName: "trash")
-      }
-      .buttonStyle(.borderless)
-      .confirmationDialog(
-        "Remove \"\(model.displayName)\"?",
-        isPresented: $showDeleteConfirmation,
-        titleVisibility: .visible
-      ) {
-        Button("Remove", role: .destructive) {
-          manager.delete(model)
+      HStack(spacing: 8) {
+        if !isActive {
+          Button("Set Active") {
+            manager.activePackage = package
+          }
         }
-      } message: {
-        Text(
-          "The model files will be deleted. You can re-download them at any time."
-        )
+        Button(role: .destructive) {
+          showDeleteConfirmation = true
+        } label: {
+          Image(systemName: "trash")
+        }
+        .buttonStyle(.borderless)
+        .confirmationDialog(
+          "Remove \"\(package.displayName)\"?",
+          isPresented: $showDeleteConfirmation,
+          titleVisibility: .visible
+        ) {
+          Button("Remove", role: .destructive) {
+            manager.deletePackage(package)
+          }
+        } message: {
+          Text(
+            "The model files will be deleted. You can re-download them at any time."
+          )
+        }
       }
       
     case .error(let message):
@@ -109,7 +132,7 @@ struct ModelRowView: View {
           .foregroundStyle(.red)
           .lineLimit(2)
         Button("Retry") {
-          manager.retry(model)
+          manager.downloadPackage(package)
         }
       }
     }

--- a/Sharkfin/StorageKey.swift
+++ b/Sharkfin/StorageKey.swift
@@ -7,4 +7,5 @@ nonisolated enum StorageKey {
   static let excludedFolderNames = "excludedFolderNames"
   static let ignoreHiddenDirectories = "ignoreHiddenDirectories"
   static let debugMode = "debugMode"
+  static let activeModelPackage = "activeModelPackage"
 }

--- a/SharkfinTests/DatabaseModelTests.swift
+++ b/SharkfinTests/DatabaseModelTests.swift
@@ -205,7 +205,7 @@ struct DatabaseModelTests {
     
     let fakeEmbedding = [Float](repeating: 0.1, count: 512)
     let embData = fakeEmbedding.withUnsafeBufferPointer { Data(buffer: $0) }
-    let embedding = FileEmbedding(fileId: file.id!, embedding: embData)
+    let embedding = FileEmbedding(fileId: file.id!, embedding: embData, modelId: CLIPModelPackage.default.id)
     try db.dbQueue.write { dbConn in try embedding.insert(dbConn) }
     
     let fetched = try db.dbQueue.read { dbConn in
@@ -237,7 +237,7 @@ struct DatabaseModelTests {
     let embData = [Float](repeating: 0, count: 512)
       .withUnsafeBufferPointer { Data(buffer: $0) }
     try db.dbQueue.write { dbConn in
-      try FileEmbedding(fileId: file.id!, embedding: embData).insert(dbConn)
+      try FileEmbedding(fileId: file.id!, embedding: embData, modelId: CLIPModelPackage.default.id).insert(dbConn)
     }
     
     try db.dbQueue.write { dbConn in

--- a/SharkfinTests/SearchServiceTests.swift
+++ b/SharkfinTests/SearchServiceTests.swift
@@ -61,7 +61,11 @@ struct SearchServiceTests {
         
         let normalized = CLIPImageEncoder.l2Normalize(file.embedding)
         let data = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
-        try FileEmbedding(fileId: f.id!, embedding: data).insert(dbConn)
+        try FileEmbedding(
+          fileId: f.id!,
+          embedding: data,
+          modelId: CLIPModelPackage.default.id
+        ).insert(dbConn)
       }
     }
     
@@ -88,7 +92,11 @@ struct SearchServiceTests {
     ])
     
     let encoder = FakeTextEncoder(embedding: queryVec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(
+      database: db,
+      textEncoder: encoder,
+      modelId: CLIPModelPackage.default.id
+    )
     let results = try await service.search(query: "test")
     
     if results.count >= 2 {
@@ -107,7 +115,11 @@ struct SearchServiceTests {
     ])
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(
+      database: db,
+      textEncoder: encoder,
+      modelId: CLIPModelPackage.default.id
+    )
     let results = try await service.search(
       query: "test",
       filters: SearchFilters(fileTypes: ["jpg"])
@@ -126,7 +138,7 @@ struct SearchServiceTests {
     let db = try seedDatabase(files: files)
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     let results = try await service.search(query: "test")
     
     #expect(results.count <= 60)
@@ -139,7 +151,7 @@ struct SearchServiceTests {
     )
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     let results = try await service.search(query: "test")
     
     #expect(results.isEmpty)
@@ -154,7 +166,7 @@ struct SearchServiceTests {
     ])
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     let results = try await service.search(query: "test")
     
     for result in results {
@@ -172,7 +184,7 @@ struct SearchServiceTests {
     ])
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     
     // First search populates cache
     _ = try await service.search(query: "test")
@@ -214,6 +226,7 @@ struct SearchServiceTests {
     let enabledDirId = enabledDir.id!
     let disabledDirId = disabledDir.id!
     
+    let defaultModelId = CLIPModelPackage.default.id
     try await db.dbQueue.write { dbConn in
       var f1 = IndexedFile(
         path: "/enabled/a.jpg",
@@ -231,7 +244,7 @@ struct SearchServiceTests {
       )
       try f1.insert(dbConn)
       let data = vec.withUnsafeBufferPointer { Data(buffer: $0) }
-      try FileEmbedding(fileId: f1.id!, embedding: data).insert(dbConn)
+      try FileEmbedding(fileId: f1.id!, embedding: data, modelId: defaultModelId).insert(dbConn)
       
       var f2 = IndexedFile(
         path: "/disabled/b.jpg",
@@ -248,11 +261,11 @@ struct SearchServiceTests {
         thumbnailPath: nil
       )
       try f2.insert(dbConn)
-      try FileEmbedding(fileId: f2.id!, embedding: data).insert(dbConn)
+      try FileEmbedding(fileId: f2.id!, embedding: data, modelId: defaultModelId).insert(dbConn)
     }
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     let results = try await service.search(query: "test")
     
     #expect(results.allSatisfy { $0.filename != "hidden.jpg" })
@@ -268,7 +281,7 @@ struct SearchServiceTests {
     ])
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     
     let sourceId = try await db.dbQueue.read { dbConn in
       try IndexedFile.filter(Column("filename") == "source.jpg")
@@ -296,6 +309,7 @@ struct SearchServiceTests {
     try db.addDirectory(&dir)
     let dirId = dir.id!
     
+    let defaultModelId = CLIPModelPackage.default.id
     try await db.dbQueue.write { dbConn in
       for (i, file) in [
         ("vacation/beach.jpg", "jpg"),
@@ -318,12 +332,12 @@ struct SearchServiceTests {
         )
         try f.insert(dbConn)
         let data = vec.withUnsafeBufferPointer { Data(buffer: $0) }
-        try FileEmbedding(fileId: f.id!, embedding: data).insert(dbConn)
+        try FileEmbedding(fileId: f.id!, embedding: data, modelId: defaultModelId).insert(dbConn)
       }
     }
     
     let encoder = FakeTextEncoder(embedding: vec)
-    let service = SearchService(database: db, textEncoder: encoder)
+    let service = SearchService(database: db, textEncoder: encoder, modelId: CLIPModelPackage.default.id)
     
     // Scope to /photos/vacation — should only return vacation files
     let vacationResults = try await service.search(


### PR DESCRIPTION
Closes #30

Adds support for downloading and activating 3 different CLIP model packages:

- CLIP ViT-B/32 (default) • ~610 MB
- CLIP ViT-B/16 • ~603 MB
- CLIP ViT-L/14 • ~1.8 GB

## Performance

Process to gather metrics:

1. Open the app, switch model
2. Index "Pictures" directory (~600 images, ~2.5 GB source file size)
3. Quit the app.
4. Restart the app.
5. Perform dummy query to load embeddings in memory.
6. Perform search in debug mode, gather results.
7. Snapshot memory usage.

### Search speed

#### B/32

```
2026-04-11 11:39:08.022 [DEBUG] [Search] "painting of a man" — 649 embeddings, 644 results
  Text encode:  0.024513208 seconds
  Cache load:   4.709e-06 seconds
  vDSP_mmul:    2.6917e-05 seconds
  Filter+sort:  0.001712292 seconds
  Total:        0.026259917 seconds
```

#### B/16

```
2026-04-11 11:36:16.484 [DEBUG] [Search] "painting of a man" — 649 embeddings, 632 results
  Text encode:  0.024773208 seconds
  Cache load:   7.708e-06 seconds
  vDSP_mmul:    0.000108375 seconds
  Filter+sort:  0.001593083 seconds
  Total:        0.026484416 seconds
```

#### L/14

```
2026-04-11 11:34:07.013 [DEBUG] [Search] "painting of a man" — 649 embeddings, 126 results
  Text encode:  0.034327708 seconds
  Cache load:   3.875e-06 seconds
  vDSP_mmul:    2.35e-05 seconds
  Filter+sort:  0.000305708 seconds
  Total:        0.034663208 seconds
```

### Memory usage

#### B/32

<img width="2130" height="1230" alt="CleanShot 2026-04-11 at 11 39 22@2x" src="https://github.com/user-attachments/assets/e1c03118-7807-470f-94a5-9951b4295ff4" />

#### B/16

<img width="2136" height="1288" alt="CleanShot 2026-04-11 at 11 36 33@2x" src="https://github.com/user-attachments/assets/fd2b1682-2aea-4adb-b244-71ee846b87b0" />

<img width="2136" height="1288" alt="CleanShot 2026-04-11 at 11 36 42@2x" src="https://github.com/user-attachments/assets/6ccc1d16-10cd-49bb-8a55-59a95aebbdd2" />

Memory dropped to a record low after the initial search.

#### L/14

<img width="2118" height="1248" alt="CleanShot 2026-04-11 at 11 34 24@2x" src="https://github.com/user-attachments/assets/4a66df49-5add-45d4-84fa-46d6cf7d5649" />

Memory for L/14 was extremely high on boot (around 1.1 GB), and stayed pretty high throughout the app's lifetime.

### Search results

#### B/32

<img width="1598" height="1532" alt="CleanShot 2026-04-11 at 11 39 09@2x" src="https://github.com/user-attachments/assets/7077d933-632a-418e-855b-184947895696" />

#### B/16

<img width="1582" height="1516" alt="CleanShot 2026-04-11 at 11 36 18@2x" src="https://github.com/user-attachments/assets/64f66775-5627-49f5-abbe-4eea07ff5e16" />

#### L/14

<img width="1590" height="1528" alt="CleanShot 2026-04-11 at 11 34 09@2x" src="https://github.com/user-attachments/assets/24fd9bab-b806-46c6-bb4b-a70943204c53" />

Honestly not great.

### Indexing speed

#### B/32

```
2026-04-11 11:44:32.177 [DEBUG] [Indexing] Directory 15 indexed in 36.580091083 seconds
```

#### B/16

```
2026-04-11 11:43:37.621 [DEBUG] [Indexing] Directory 15 indexed in 49.406306084 seconds
```

#### L/14

```
2026-04-11 11:42:28.497 [DEBUG] [Indexing] Directory 15 indexed in 85.45244012500001 seconds
```